### PR TITLE
Remove live1.chilli as a host

### DIFF
--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -6,7 +6,6 @@ wordpress_sites:
   solidtimberbenchtops.com.au:
     site_hosts:
       - www.solidtimberbenchtops.com.au
-#      - atl.live1.chillidevelopment.com
     local_path: ../solidtimberbenchtops.com.au # path targeting local Bedrock site directory (relative to Ansible root)
     repo: git@github.com:ChilliCreative/solidtimberbenchtops.com.au.git # replace with your Git repo URL
     #repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo

--- a/hosts/production
+++ b/hosts/production
@@ -2,9 +2,7 @@
 # List each machine only once per [group], even if it will host multiple sites.
 
 [production]
-live1.chillidevelopment.com
 solidtimberbenchtops.com.au
 
 [web]
-live1.chillidevelopment.com
 solidtimberbenchtops.com.au


### PR DESCRIPTION
Used to deploy to server before domain name had propagated.
